### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brian-reichle @yaakov-h


### PR DESCRIPTION
This is to enable the "Require review from Code Owners" branch protection policy.