### PR TITLE
[Experimental] Add MCP server for analysis and bulk-fixing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build Artifacts
 obj
 bin
+artifacts
 
 # Visual Studio
 .vs

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,13 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- WTG1005 (line-ending consistency) is platform-dependent (uses Environment.NewLine);
+         the repo uses CRLF for its Windows CI, so suppress it to allow cross-platform builds. -->
+    <NoWarn>$(NoWarn);WTG1005</NoWarn>
+    <!-- Audit only our direct dependencies. The Roslyn/MSBuild tooling tree pulls transitive
+         packages (compile-time only; excluded from runtime) whose advisories we cannot control
+         and which would otherwise fail the build via TreatWarningsAsErrors. -->
+    <NuGetAuditMode>direct</NuGetAuditMode>
 
     <Version>4.0.0.0</Version>
 
@@ -28,4 +35,17 @@
       <Link>Properties\stylecop.json</Link>
     </AdditionalFiles>
   </ItemGroup>
+
+  <!-- Roslyn's Workspaces.MSBuild pulls MSBuild assemblies transitively. MSBuildLocator supplies the
+       real MSBuild from the installed SDK at runtime, so these must NOT be copied to output
+       (ExcludeAssets=runtime, satisfying MSBL001). They are pinned to a patched build to avoid the
+       known vulnerability in the version Roslyn would otherwise select transitively (NU1903). -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,9 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- Per-project isolated output under artifacts/ (avoids a shared flat bin where projects'
+         differing transitive dependency versions collide). -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
     <!-- WTG1005 (line-ending consistency) is platform-dependent (uses Environment.NewLine);
          the repo uses CRLF for its Windows CI, so suppress it to allow cross-platform builds. -->
     <NoWarn>$(NoWarn);WTG1005</NoWarn>
@@ -27,7 +30,6 @@
     <WTGAnalyzersWarnAll>true</WTGAnalyzersWarnAll>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
 
-    <OutputPath>$(MSBuildThisFileDirectory)bin</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,16 +38,12 @@
     </AdditionalFiles>
   </ItemGroup>
 
-  <!-- Roslyn's Workspaces.MSBuild pulls MSBuild assemblies transitively. MSBuildLocator supplies the
-       real MSBuild from the installed SDK at runtime, so these must NOT be copied to output
-       (ExcludeAssets=runtime, satisfying MSBL001). They are pinned to a patched build to avoid the
-       known vulnerability in the version Roslyn would otherwise select transitively (NU1903). -->
+  <!-- Roslyn's Workspaces.MSBuild (5.x) pulls Microsoft.Build.Framework transitively. MSBuildLocator
+       (and the out-of-process BuildHost) supply the real MSBuild from the installed SDK at runtime, so
+       it must NOT be copied to output (ExcludeAssets=runtime, satisfying MSBuildLocator's MSBL001).
+       Pinned to the version Roslyn 5.3 expects. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.StringTools" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/BulkAnalysisRunner.sln
+++ b/src/BulkAnalysisRunner.sln
@@ -9,23 +9,65 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WTG.BulkAnalysis.Core", "WT
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WTG.BulkAnalysis.Test", "WTG.BulkAnalysis.Test\WTG.BulkAnalysis.Test.csproj", "{F440B628-0C1E-4C5C-9BDF-EA0D62219678}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WTG.BulkAnalysis.Mcp", "WTG.BulkAnalysis.Mcp\WTG.BulkAnalysis.Mcp.csproj", "{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CC915472-4531-448B-8D01-9FD9D036D451}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CC915472-4531-448B-8D01-9FD9D036D451}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Debug|x64.Build.0 = Debug|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Debug|x86.Build.0 = Debug|Any CPU
 		{CC915472-4531-448B-8D01-9FD9D036D451}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC915472-4531-448B-8D01-9FD9D036D451}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Release|x64.ActiveCfg = Release|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Release|x64.Build.0 = Release|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Release|x86.ActiveCfg = Release|Any CPU
+		{CC915472-4531-448B-8D01-9FD9D036D451}.Release|x86.Build.0 = Release|Any CPU
 		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Debug|x64.Build.0 = Debug|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Debug|x86.Build.0 = Debug|Any CPU
 		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Release|x64.ActiveCfg = Release|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Release|x64.Build.0 = Release|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Release|x86.ActiveCfg = Release|Any CPU
+		{EF81C8B4-A10D-4606-801E-D3DD02E1BFBE}.Release|x86.Build.0 = Release|Any CPU
 		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Debug|x64.Build.0 = Debug|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Debug|x86.Build.0 = Debug|Any CPU
 		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Release|x64.ActiveCfg = Release|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Release|x64.Build.0 = Release|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Release|x86.ActiveCfg = Release|Any CPU
+		{F440B628-0C1E-4C5C-9BDF-EA0D62219678}.Release|x86.Build.0 = Release|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Release|x64.Build.0 = Release|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6CC7782-A8F0-41AE-A9F9-3BF4563D30C0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WTG.BulkAnalysis.Core/AnalysisSession.cs
+++ b/src/WTG.BulkAnalysis.Core/AnalysisSession.cs
@@ -162,8 +162,11 @@ namespace WTG.BulkAnalysis.Core
 
 				var providers = cache.GetAllCodeFixProviders(project);
 
+				// Pass the project's AnalyzerOptions so the analyzer driver honours the project's
+				// .editorconfig and global analyzer config (severities and suppressions) and sees its
+				// AdditionalFiles, matching what the build would report.
 				var diagnostics = await compilation
-					.WithAnalyzers(analyzers, EmptyCompilationWithAnalyzersOptions)
+					.WithAnalyzers(analyzers, CreateAnalyzerOptions(project))
 					.GetAnalyzerDiagnosticsAsync(cancellationToken)
 					.ConfigureAwait(false);
 
@@ -258,10 +261,10 @@ namespace WTG.BulkAnalysis.Core
 		readonly ILog log;
 		readonly SemaphoreSlim gate = new SemaphoreSlim(1, 1);
 
-		static readonly CompilationWithAnalyzersOptions EmptyCompilationWithAnalyzersOptions = new CompilationWithAnalyzersOptions(
-			new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()),
-			null,
-			true,
-			false);
+		static CompilationWithAnalyzersOptions CreateAnalyzerOptions(Project project) => new CompilationWithAnalyzersOptions(
+			project.AnalyzerOptions,
+			onAnalyzerException: null,
+			concurrentAnalysis: true,
+			logAnalyzerExecutionTime: false);
 	}
 }

--- a/src/WTG.BulkAnalysis.Core/AnalysisSession.cs
+++ b/src/WTG.BulkAnalysis.Core/AnalysisSession.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace WTG.BulkAnalysis.Core
+{
+	/// <summary>
+	/// A stateful, in-memory analysis session over a single solution or project. The workspace and
+	/// analyzers are loaded once (an expensive operation) and reused across analyze/fix calls.
+	/// Callers must register an MSBuild instance (e.g. via MSBuildLocator) before opening a session.
+	/// </summary>
+	public sealed class AnalysisSession : IDisposable
+	{
+		AnalysisSession(MSBuildWorkspace workspace, AnalyzerCache cache, AnalysisSessionOptions options, ILog log)
+		{
+			this.workspace = workspace;
+			this.cache = cache;
+			this.options = options;
+			this.log = log;
+		}
+
+		public string TargetPath => options.Path;
+
+		public ImmutableArray<string> ProjectNames => workspace.CurrentSolution.Projects
+			.Where(p => p.Language == LanguageNames.CSharp)
+			.Select(p => p.Name)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToImmutableArray();
+
+		public static async Task<AnalysisSession> OpenAsync(AnalysisSessionOptions options, ILog log, CancellationToken cancellationToken)
+		{
+			if (options == null)
+			{
+				throw new ArgumentNullException(nameof(options));
+			}
+
+			if (log == null)
+			{
+				throw new ArgumentNullException(nameof(log));
+			}
+
+			var properties = new Dictionary<string, string>()
+			{
+				{ "Configuration", options.Configuration },
+			};
+
+			var workspace = MSBuildWorkspace.Create(properties);
+
+			try
+			{
+				await LoadAsync(workspace, options.Path, log, cancellationToken).ConfigureAwait(false);
+				Processor.ConfigureWorkspace(workspace);
+
+				var cache = AnalyzerCache.CreateForDiscovery(options.LoadDir ?? string.Empty, options.LoadList);
+				return new AnalysisSession(workspace, cache, options, log);
+			}
+			catch
+			{
+				workspace.Dispose();
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Runs every loaded analyzer over the C# projects and returns the resulting diagnostics.
+		/// When <paramref name="ruleIds"/> is <c>null</c> all diagnostics are returned (discovery);
+		/// otherwise the result is limited to the given rule ids.
+		/// </summary>
+		public async Task<ImmutableArray<DiagnosticInfo>> AnalyzeAsync(ImmutableHashSet<string>? ruleIds, CancellationToken cancellationToken)
+		{
+			await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+			try
+			{
+				return await AnalyzeCoreAsync(workspace.CurrentSolution, ruleIds, cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				gate.Release();
+			}
+		}
+
+		/// <summary>
+		/// Applies fix-all operations for the requested rule ids until no further changes are made,
+		/// writing the results to disk, and reports what changed and what remains.
+		/// </summary>
+		public async Task<FixResult> ApplyFixesAsync(ImmutableHashSet<string> ruleIds, CancellationToken cancellationToken)
+		{
+			if (ruleIds == null || ruleIds.Count == 0)
+			{
+				throw new ArgumentException("At least one rule id is required.", nameof(ruleIds));
+			}
+
+			await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+			try
+			{
+				var before = workspace.CurrentSolution;
+
+				// Reuse the proven CLI fix loop (analyze -> fix-all -> repeat until stable), scoped to the requested rules.
+				var context = new RunContext(
+					ImmutableArray<string>.Empty,
+					applyFixes: true,
+					ruleIds,
+					options.LoadDir ?? string.Empty,
+					options.LoadList,
+					log,
+					reporter: null,
+					options.Configuration,
+					debug: false,
+					cancellationToken);
+
+				var processor = new SolutionProcessor(context, cache, workspace);
+				var operationsApplied = await processor.ProcessSolutionAsync().ConfigureAwait(false);
+
+				var after = workspace.CurrentSolution;
+				var changedFiles = GetChangedFiles(before, after);
+
+				var remaining = await AnalyzeCoreAsync(after, ruleIds, cancellationToken).ConfigureAwait(false);
+				var remainingByRule = remaining
+					.GroupBy(d => d.Id)
+					.ToImmutableDictionary(g => g.Key, g => g.Count());
+
+				return new FixResult(operationsApplied, changedFiles, remainingByRule);
+			}
+			finally
+			{
+				gate.Release();
+			}
+		}
+
+		async Task<ImmutableArray<DiagnosticInfo>> AnalyzeCoreAsync(Solution solution, ImmutableHashSet<string>? ruleIds, CancellationToken cancellationToken)
+		{
+			var builder = ImmutableArray.CreateBuilder<DiagnosticInfo>();
+
+			foreach (var project in solution.Projects)
+			{
+				if (project.Language != LanguageNames.CSharp)
+				{
+					continue;
+				}
+
+				var analyzers = cache.GetAnalyzers(project);
+
+				if (analyzers.Length == 0)
+				{
+					continue;
+				}
+
+				var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+				if (compilation == null)
+				{
+					continue;
+				}
+
+				var providers = cache.GetAllCodeFixProviders(project);
+
+				var diagnostics = await compilation
+					.WithAnalyzers(analyzers, EmptyCompilationWithAnalyzersOptions)
+					.GetAnalyzerDiagnosticsAsync(cancellationToken)
+					.ConfigureAwait(false);
+
+				foreach (var diagnostic in diagnostics)
+				{
+					if (ruleIds != null && !ruleIds.Contains(diagnostic.Id))
+					{
+						continue;
+					}
+
+					builder.Add(DiagnosticInfo.Create(diagnostic, project.Name, providers.ContainsKey(diagnostic.Id)));
+				}
+			}
+
+			return builder.ToImmutable();
+		}
+
+		static async Task LoadAsync(MSBuildWorkspace workspace, string path, ILog log, CancellationToken cancellationToken)
+		{
+			try
+			{
+				if (path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+				{
+					await workspace.OpenProjectAsync(path, cancellationToken: cancellationToken).ConfigureAwait(false);
+				}
+				else if (path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) || path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+				{
+					await workspace.OpenSolutionAsync(path, cancellationToken: cancellationToken).ConfigureAwait(false);
+				}
+				else
+				{
+					throw new InvalidConfigurationException("Unsupported target '" + path + "'. Expected a .sln, .slnx or .csproj path.");
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
+			catch (InvalidConfigurationException)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				throw new WorkspaceLoadException("Error loading '" + path + "'.", ex);
+			}
+
+			foreach (var diagnostic in workspace.Diagnostics)
+			{
+				switch (diagnostic.Kind)
+				{
+					case WorkspaceDiagnosticKind.Failure:
+						log.WriteLine(diagnostic.Message, LogLevel.Error);
+						break;
+
+					case WorkspaceDiagnosticKind.Warning:
+						log.WriteLine(diagnostic.Message, LogLevel.Warning);
+						break;
+				}
+			}
+		}
+
+		static ImmutableArray<string> GetChangedFiles(Solution before, Solution after)
+		{
+			var files = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+			foreach (var projectChange in after.GetChanges(before).GetProjectChanges())
+			{
+				foreach (var documentId in projectChange.GetChangedDocuments().Concat(projectChange.GetAddedDocuments()))
+				{
+					var path = after.GetDocument(documentId)?.FilePath;
+
+					if (!string.IsNullOrEmpty(path))
+					{
+						files.Add(path!);
+					}
+				}
+			}
+
+			return files.ToImmutableArray();
+		}
+
+		public void Dispose()
+		{
+			workspace.Dispose();
+			gate.Dispose();
+		}
+
+		readonly MSBuildWorkspace workspace;
+		readonly AnalyzerCache cache;
+		readonly AnalysisSessionOptions options;
+		readonly ILog log;
+		readonly SemaphoreSlim gate = new SemaphoreSlim(1, 1);
+
+		static readonly CompilationWithAnalyzersOptions EmptyCompilationWithAnalyzersOptions = new CompilationWithAnalyzersOptions(
+			new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()),
+			null,
+			true,
+			false);
+	}
+}

--- a/src/WTG.BulkAnalysis.Core/AnalysisSessionOptions.cs
+++ b/src/WTG.BulkAnalysis.Core/AnalysisSessionOptions.cs
@@ -1,0 +1,31 @@
+using System.Collections.Immutable;
+
+namespace WTG.BulkAnalysis.Core
+{
+	public sealed class AnalysisSessionOptions
+	{
+		public AnalysisSessionOptions(
+			string path,
+			string configuration,
+			string? loadDir,
+			ImmutableArray<string> loadList)
+		{
+			Path = path;
+			Configuration = configuration;
+			LoadDir = loadDir;
+			LoadList = loadList.IsDefault ? ImmutableArray<string>.Empty : loadList;
+		}
+
+		/// <summary>Path to the solution (.sln/.slnx) or project (.csproj) to open.</summary>
+		public string Path { get; }
+
+		/// <summary>The build configuration to load, e.g. "Debug" or "Release".</summary>
+		public string Configuration { get; }
+
+		/// <summary>Optional directory to load analyzer/code-fix assemblies from instead of the project's references.</summary>
+		public string? LoadDir { get; }
+
+		/// <summary>Optional explicit list of analyzer assemblies to load. When empty, the project's references are used.</summary>
+		public ImmutableArray<string> LoadList { get; }
+	}
+}

--- a/src/WTG.BulkAnalysis.Core/AnalyzerAssemblyResolver.cs
+++ b/src/WTG.BulkAnalysis.Core/AnalyzerAssemblyResolver.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace WTG.BulkAnalysis.Core
+{
+	/// <summary>
+	/// Analyzer assemblies are loaded with <see cref="Assembly.LoadFile(string)"/>, which does not probe
+	/// for an assembly's dependencies. This resolves them from the requesting assembly's own directory so
+	/// analyzers that ship a separate dependency (e.g. a *.Utils.dll) can run instead of throwing at
+	/// execution time (which surfaces as AD0001). Call <see cref="Register"/> once at host start-up.
+	/// </summary>
+	public static class AnalyzerAssemblyResolver
+	{
+		public static void Register()
+		{
+			if (registered)
+			{
+				return;
+			}
+
+			registered = true;
+			AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+		}
+
+		static Assembly? OnAssemblyResolve(object? sender, ResolveEventArgs args)
+		{
+			var requester = args.RequestingAssembly;
+
+			if (requester == null || string.IsNullOrEmpty(requester.Location))
+			{
+				return null;
+			}
+
+			var directory = Path.GetDirectoryName(requester.Location);
+			var name = new AssemblyName(args.Name).Name;
+
+			if (directory == null || name == null)
+			{
+				return null;
+			}
+
+			var candidate = Path.Combine(directory, name + ".dll");
+			return File.Exists(candidate) ? Assembly.LoadFile(candidate) : null;
+		}
+
+		static bool registered;
+	}
+}

--- a/src/WTG.BulkAnalysis.Core/CodeFixException.cs
+++ b/src/WTG.BulkAnalysis.Core/CodeFixException.cs
@@ -1,5 +1,7 @@
 using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace WTG.BulkAnalysis.Core
 {
@@ -20,9 +22,11 @@ namespace WTG.BulkAnalysis.Core
 		{
 		}
 
+#if NETFRAMEWORK
 		protected CodeFixException(SerializationInfo serializationInfo, StreamingContext streamingContext)
 			: base(serializationInfo, streamingContext)
 		{
 		}
+#endif
 	}
 }

--- a/src/WTG.BulkAnalysis.Core/DiagnosticInfo.cs
+++ b/src/WTG.BulkAnalysis.Core/DiagnosticInfo.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+
+namespace WTG.BulkAnalysis.Core
+{
+	public sealed class DiagnosticInfo
+	{
+		public DiagnosticInfo(
+			string id,
+			string title,
+			string message,
+			string severity,
+			string category,
+			string projectName,
+			string? filePath,
+			int startLine,
+			int startColumn,
+			int endLine,
+			int endColumn,
+			bool hasCodeFix)
+		{
+			Id = id;
+			Title = title;
+			Message = message;
+			Severity = severity;
+			Category = category;
+			ProjectName = projectName;
+			FilePath = filePath;
+			StartLine = startLine;
+			StartColumn = startColumn;
+			EndLine = endLine;
+			EndColumn = endColumn;
+			HasCodeFix = hasCodeFix;
+		}
+
+		public string Id { get; }
+		public string Title { get; }
+		public string Message { get; }
+		public string Severity { get; }
+		public string Category { get; }
+		public string ProjectName { get; }
+
+		/// <summary>The source file the diagnostic points at, or <c>null</c> for project-level diagnostics.</summary>
+		public string? FilePath { get; }
+
+		// Positions are 1-based for human/agent friendliness (Roslyn reports 0-based), or 0 when not in source.
+		public int StartLine { get; }
+		public int StartColumn { get; }
+		public int EndLine { get; }
+		public int EndColumn { get; }
+
+		/// <summary>Whether at least one loaded code fix provider can fix this diagnostic's rule.</summary>
+		public bool HasCodeFix { get; }
+
+		public static DiagnosticInfo Create(Diagnostic diagnostic, string projectName, bool hasCodeFix)
+		{
+			var inSource = diagnostic.Location.IsInSource;
+			var span = diagnostic.Location.GetLineSpan();
+			var start = span.StartLinePosition;
+			var end = span.EndLinePosition;
+
+			return new DiagnosticInfo(
+				diagnostic.Id,
+				diagnostic.Descriptor.Title.ToString(CultureInfo.CurrentCulture),
+				diagnostic.GetMessage(CultureInfo.CurrentCulture),
+				diagnostic.Severity.ToString(),
+				diagnostic.Descriptor.Category,
+				projectName,
+				inSource ? span.Path : null,
+				inSource ? start.Line + 1 : 0,
+				inSource ? start.Character + 1 : 0,
+				inSource ? end.Line + 1 : 0,
+				inSource ? end.Character + 1 : 0,
+				hasCodeFix);
+		}
+	}
+}

--- a/src/WTG.BulkAnalysis.Core/FixResult.cs
+++ b/src/WTG.BulkAnalysis.Core/FixResult.cs
@@ -1,0 +1,26 @@
+using System.Collections.Immutable;
+
+namespace WTG.BulkAnalysis.Core
+{
+	public sealed class FixResult
+	{
+		public FixResult(
+			int operationsApplied,
+			ImmutableArray<string> changedFiles,
+			ImmutableDictionary<string, int> remainingByRule)
+		{
+			OperationsApplied = operationsApplied;
+			ChangedFiles = changedFiles;
+			RemainingByRule = remainingByRule;
+		}
+
+		/// <summary>Number of fix-all operations applied to the workspace (and written to disk).</summary>
+		public int OperationsApplied { get; }
+
+		/// <summary>Absolute paths of the source files that were changed on disk.</summary>
+		public ImmutableArray<string> ChangedFiles { get; }
+
+		/// <summary>For each requested rule id, the number of diagnostics still remaining after fixing.</summary>
+		public ImmutableDictionary<string, int> RemainingByRule { get; }
+	}
+}

--- a/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
@@ -14,14 +14,20 @@ namespace WTG.BulkAnalysis.Core
 	abstract class AnalyzerCache
 	{
 		public static AnalyzerCache Create(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList)
+			=> Create(diagnosticIds, loadDir, loadList, discoverAll: false);
+
+		public static AnalyzerCache CreateForDiscovery(string loadDir, ImmutableArray<string> loadList)
+			=> Create(ImmutableHashSet<string>.Empty, loadDir, loadList, discoverAll: true);
+
+		static AnalyzerCache Create(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, bool discoverAll)
 		{
 			if (loadList.Length > 0)
 			{
-				return new Explicit(diagnosticIds, loadDir, loadList);
+				return new Explicit(diagnosticIds, loadDir, loadList, discoverAll);
 			}
 			else
 			{
-				return new Implicit(diagnosticIds, loadDir);
+				return new Implicit(diagnosticIds, loadDir, discoverAll);
 			}
 		}
 
@@ -32,27 +38,55 @@ namespace WTG.BulkAnalysis.Core
 		{
 			var assembly = Assembly.LoadFile(assemblyPath);
 
-			foreach (var type in assembly.GetTypes())
-			{
-				if (!type.IsAbstract && type.IsSubclassOf(typeof(T)))
-				{
-					var instance = (T)Activator.CreateInstance(type);
+			// Discovery loads every referenced analyzer assembly; some may be built against a different
+			// Roslyn version and fail to fully load. Use the types that did load and skip the rest.
+			Type?[] types;
 
-					if (filter(instance))
-					{
-						yield return instance;
-					}
+			try
+			{
+				types = assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException ex)
+			{
+				types = ex.Types;
+			}
+
+			var result = new List<T>();
+
+			foreach (var type in types)
+			{
+				if (type == null || type.IsAbstract || !type.IsSubclassOf(typeof(T)))
+				{
+					continue;
+				}
+
+				T instance;
+
+				try
+				{
+					instance = (T)Activator.CreateInstance(type)!;
+				}
+				catch (Exception)
+				{
+					continue;
+				}
+
+				if (filter(instance))
+				{
+					result.Add(instance);
 				}
 			}
+
+			return result;
 		}
 
 		sealed class Implicit : AnalyzerCache
 		{
-			public Implicit(ImmutableHashSet<string> diagnosticIds, string loadDir)
+			public Implicit(ImmutableHashSet<string> diagnosticIds, string loadDir, bool discoverAll)
 			{
 				this.loadDir = loadDir;
-				analyzerFilter = a => a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
-				providerFilter = p => p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
+				analyzerFilter = a => discoverAll || a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
+				providerFilter = p => discoverAll || p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
 				analyzerLookup = new ConcurrentDictionary<string, ImmutableArray<DiagnosticAnalyzer>>();
 				providerLookup = new ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>>();
 			}
@@ -142,10 +176,10 @@ namespace WTG.BulkAnalysis.Core
 
 		sealed class Explicit : AnalyzerCache
 		{
-			public Explicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList)
+			public Explicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, bool discoverAll)
 			{
-				Predicate<DiagnosticAnalyzer> analyzerFilter = a => a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
-				Predicate<CodeFixProvider> providerFilter = p => p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
+				Predicate<DiagnosticAnalyzer> analyzerFilter = a => discoverAll || a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
+				Predicate<CodeFixProvider> providerFilter = p => discoverAll || p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
 
 				var paths = PrefixPaths(loadDir, loadList);
 
@@ -155,7 +189,7 @@ namespace WTG.BulkAnalysis.Core
 					from path in paths
 					from provider in Get(path, providerFilter)
 					from id in provider.FixableDiagnosticIds
-					where diagnosticIds.Contains(id)
+					where discoverAll || diagnosticIds.Contains(id)
 					group provider by id into g
 					select g,
 					x => x.Key,

--- a/src/WTG.BulkAnalysis.Core/Internal/SolutionProcessor.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/SolutionProcessor.cs
@@ -178,10 +178,16 @@ namespace WTG.BulkAnalysis.Core
 				return ImmutableArray<Diagnostic>.Empty;
 			}
 
+			// Pass the project's AnalyzerOptions so editorconfig / global analyzer config severities and
+			// suppressions (and AdditionalFiles) are honoured, matching the build's effective results.
 			var compilationWithAnalyzers = compilation
 				.WithAnalyzers(
 					analyzers,
-					EmptyCompilationWithAnalyzersOptions);
+					new CompilationWithAnalyzersOptions(
+						project.AnalyzerOptions,
+						onAnalyzerException: null,
+						concurrentAnalysis: true,
+						logAnalyzerExecutionTime: false));
 
 			var diagnostics = await compilationWithAnalyzers
 				.GetAllDiagnosticsAsync(context.CancellationToken)
@@ -225,12 +231,6 @@ namespace WTG.BulkAnalysis.Core
 		}
 
 		static readonly ImmutableList<CodeFixProvider> EmptyCodeFixProviderList = ImmutableList.Create<CodeFixProvider>();
-
-		static readonly CompilationWithAnalyzersOptions EmptyCompilationWithAnalyzersOptions = new CompilationWithAnalyzersOptions(
-			new AnalyzerOptions(ImmutableArray.Create<AdditionalText>()),
-			null,
-			true,
-			false);
 
 		readonly RunContext context;
 		readonly AnalyzerCache cache;

--- a/src/WTG.BulkAnalysis.Core/Internal/SolutionProcessor.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/SolutionProcessor.cs
@@ -18,7 +18,7 @@ namespace WTG.BulkAnalysis.Core
 			this.workspace = workspace;
 		}
 
-		public async Task ProcessSolutionAsync()
+		public async Task<int> ProcessSolutionAsync()
 		{
 			var operationsCounter = 0;
 			var numPreviousDiagnostics = 0;
@@ -67,6 +67,8 @@ namespace WTG.BulkAnalysis.Core
 			{
 				context.Log.WriteFormatted($"  - Applied {operationsCounter} fix-all operations to resolve errors.", LogLevel.Info);
 			}
+
+			return operationsCounter;
 		}
 
 		async Task<int> ApplyFixesAsync(Solution solution, ImmutableDictionary<ProjectId, ImmutableArray<Diagnostic>> diagnostics)

--- a/src/WTG.BulkAnalysis.Core/InvalidConfigurationException.cs
+++ b/src/WTG.BulkAnalysis.Core/InvalidConfigurationException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace WTG.BulkAnalysis.Core
 {
@@ -20,9 +22,11 @@ namespace WTG.BulkAnalysis.Core
 		{
 		}
 
+#if NETFRAMEWORK
 		protected InvalidConfigurationException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{
 		}
+#endif
 	}
 }

--- a/src/WTG.BulkAnalysis.Core/Processor.cs
+++ b/src/WTG.BulkAnalysis.Core/Processor.cs
@@ -117,7 +117,7 @@ namespace WTG.BulkAnalysis.Core
 			}
 		}
 
-		static void ConfigureWorkspace(Workspace workspace)
+		internal static void ConfigureWorkspace(Workspace workspace)
 		{
 			Solution solution;
 

--- a/src/WTG.BulkAnalysis.Core/SolutionLocator.cs
+++ b/src/WTG.BulkAnalysis.Core/SolutionLocator.cs
@@ -79,6 +79,7 @@ namespace WTG.BulkAnalysis.Core
 				throw new InvalidConfigurationException("Error reading '" + path + "': Invalid root element.");
 			}
 
+			// Build.xml stores Windows-style separators; normalise so paths resolve on any platform.
 			return
 				from solutionsElement in root.Elements()
 				where solutionsElement.Name.LocalName == "Solutions"
@@ -86,7 +87,7 @@ namespace WTG.BulkAnalysis.Core
 				where solutionElement.Name.LocalName == "Solution"
 				let filename = solutionElement.Attribute("Filename")?.Value
 				where filename != null
-				select filename;
+				select filename.Replace('\\', Path.DirectorySeparatorChar);
 		}
 
 		static bool IsPathPrefix(string path, string prefix)

--- a/src/WTG.BulkAnalysis.Core/SolutionLocator.cs
+++ b/src/WTG.BulkAnalysis.Core/SolutionLocator.cs
@@ -48,12 +48,14 @@ namespace WTG.BulkAnalysis.Core
 					throw new InvalidConfigurationException("Directory does not exist, '" + pathToBranch + "'.");
 				}
 
-				pathToBranch = Path.GetDirectoryName(pathToBranch);
+				var parent = Path.GetDirectoryName(pathToBranch);
 
-				if (pathToBranch == null)
+				if (parent == null)
 				{
 					throw new InvalidConfigurationException("Build.xml could be found.");
 				}
+
+				pathToBranch = parent;
 			}
 		}
 

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -5,17 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Roslyn 4.7.0 is the last release whose MSBuildWorkspace loads MSBuild IN-PROCESS. 4.8+ uses a
-         separate out-of-process BuildHost that fails to connect when hosted under an stdio MCP server.
-         4.7.0 is also Roslyn 4.x, so analyzers in the wild (WTG.Analyzers, StyleCop, NetAnalyzers) built
-         for Roslyn 4.x run correctly instead of crashing (AD0001) as they do on the 5.x runtime.
-         MSBuildLocator supplies the actual MSBuild from the installed .NET SDK at runtime. -->
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0" />
+    <!-- Roslyn 5.x matches the .NET 10 SDK's compiler, so it can parse modern C# (e.g. C# 14 extension
+         members). Older lines (e.g. 4.7) only parse up to C# 11 and misparse modern targets, producing
+         spurious diagnostics. MSBuildWorkspace evaluates projects out-of-process via its BuildHost;
+         MSBuildLocator supplies the .NET SDK MSBuild. -->
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <!-- Roslyn 4.7.0 is the last release whose MSBuildWorkspace loads MSBuild IN-PROCESS. 4.8+ uses a
+         separate out-of-process BuildHost that fails to connect when hosted under an stdio MCP server.
+         4.7.0 is also Roslyn 4.x, so analyzers in the wild (WTG.Analyzers, StyleCop, NetAnalyzers) built
+         for Roslyn 4.x run correctly instead of crashing (AD0001) as they do on the 5.x runtime.
+         MSBuildLocator supplies the actual MSBuild from the installed .NET SDK at runtime. -->
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.BulkAnalysis.Core/WorkspaceLoadException.cs
+++ b/src/WTG.BulkAnalysis.Core/WorkspaceLoadException.cs
@@ -1,5 +1,7 @@
 using System;
+#if NETFRAMEWORK
 using System.Runtime.Serialization;
+#endif
 
 namespace WTG.BulkAnalysis.Core
 {
@@ -20,9 +22,11 @@ namespace WTG.BulkAnalysis.Core
 		{
 		}
 
+#if NETFRAMEWORK
 		protected WorkspaceLoadException(SerializationInfo serializationInfo, StreamingContext streamingContext)
 			: base(serializationInfo, streamingContext)
 		{
 		}
+#endif
 	}
 }

--- a/src/WTG.BulkAnalysis.Mcp/AnalysisTools.cs
+++ b/src/WTG.BulkAnalysis.Mcp/AnalysisTools.cs
@@ -70,12 +70,14 @@ namespace WTG.BulkAnalysis.Mcp
 
 		[McpServerTool(Name = "list_diagnostics")]
 		[Description("Run all analyzers and return a grouped summary of the diagnostics. Each group reports its count " +
-			"and whether a code fix provider is available (hasCodeFix), so you can tell what is bulk-fixable.")]
+			"and whether a code fix provider is available (hasCodeFix), so you can tell what is bulk-fixable. " +
+			"By default only Warning and Error are returned (what a build surfaces); pass minSeverity to include " +
+			"lower-severity (Info/Hidden) suggestions.")]
 		public static async Task<ListDiagnosticsResult> ListDiagnosticsAsync(
 			SessionManager sessions,
 			[Description("Session id from open_analysis.")] string sessionId,
 			[Description("Optional ';'-separated rule ids to limit the results to.")] string? ruleIds = null,
-			[Description("Optional minimum severity: Hidden, Info, Warning or Error.")] string? minSeverity = null,
+			[Description("Minimum severity: Hidden, Info, Warning or Error. Defaults to Warning (build-actionable).")] string minSeverity = "Warning",
 			[Description("How to group results: rule (default), severity, project or fixability.")] string groupBy = "rule",
 			CancellationToken cancellationToken = default)
 		{

--- a/src/WTG.BulkAnalysis.Mcp/AnalysisTools.cs
+++ b/src/WTG.BulkAnalysis.Mcp/AnalysisTools.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using WTG.BulkAnalysis.Core;
+
+namespace WTG.BulkAnalysis.Mcp
+{
+	[McpServerToolType]
+	public static class AnalysisTools
+	{
+		[McpServerTool(Name = "open_analysis")]
+		[Description("Open a solution or project for analysis and keep it loaded in memory for subsequent calls. " +
+			"Accepts a .sln/.slnx/.csproj path, or a directory/branch containing a Build.xml to discover solutions. " +
+			"Returns a sessionId used by the other tools.")]
+		public static async Task<OpenResult> OpenAnalysisAsync(
+			SessionManager sessions,
+			ILoggerFactory loggerFactory,
+			[Description("Path to a .sln/.slnx/.csproj file, or a directory/branch containing a Build.xml.")] string path,
+			[Description("Build configuration to load (e.g. Debug or Release).")] string configuration = "Debug",
+			[Description("Optional directory to load analyzer/code-fix assemblies from instead of the project's references.")] string? loadDir = null,
+			[Description("Optional ';'-separated list of analyzer assemblies to load.")] string? load = null,
+			[Description("Optional regex to filter discovered solutions when a directory/branch is given.")] string? filter = null,
+			CancellationToken cancellationToken = default)
+		{
+			var full = Path.GetFullPath(path);
+			string resolved;
+
+			if (IsProjectOrSolutionFile(full))
+			{
+				resolved = full;
+			}
+			else
+			{
+				var found = SolutionLocator.Locate(full, BuildFilter(filter));
+
+				if (found.Length == 0)
+				{
+					return new OpenResult(null, path, Array.Empty<string>(), null, "No solutions were found. Provide a .sln/.csproj path, or a directory containing a Build.xml.");
+				}
+
+				if (found.Length > 1)
+				{
+					return new OpenResult(null, path, Array.Empty<string>(), found, "Multiple solutions were found. Re-run with a specific .sln path or a 'filter' regex.");
+				}
+
+				resolved = found[0];
+			}
+
+			var loadList = string.IsNullOrWhiteSpace(load)
+				? ImmutableArray<string>.Empty
+				: load.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToImmutableArray();
+
+			var options = new AnalysisSessionOptions(resolved, configuration, loadDir, loadList);
+			var log = new McpLog(loggerFactory.CreateLogger("WTG.BulkAnalysis"));
+
+			var session = await AnalysisSession.OpenAsync(options, log, cancellationToken).ConfigureAwait(false);
+			var projects = session.ProjectNames;
+			var id = sessions.Add(session);
+
+			return new OpenResult(id, resolved, projects, null, $"Opened with {projects.Length} C# project(s).");
+		}
+
+		[McpServerTool(Name = "list_diagnostics")]
+		[Description("Run all analyzers and return a grouped summary of the diagnostics. Each group reports its count " +
+			"and whether a code fix provider is available (hasCodeFix), so you can tell what is bulk-fixable.")]
+		public static async Task<ListDiagnosticsResult> ListDiagnosticsAsync(
+			SessionManager sessions,
+			[Description("Session id from open_analysis.")] string sessionId,
+			[Description("Optional ';'-separated rule ids to limit the results to.")] string? ruleIds = null,
+			[Description("Optional minimum severity: Hidden, Info, Warning or Error.")] string? minSeverity = null,
+			[Description("How to group results: rule (default), severity, project or fixability.")] string groupBy = "rule",
+			CancellationToken cancellationToken = default)
+		{
+			var session = Get(sessions, sessionId);
+			var diagnostics = await session.AnalyzeAsync(ParseIds(ruleIds), cancellationToken).ConfigureAwait(false);
+			var filtered = ApplyMinSeverity(diagnostics, minSeverity);
+
+			var groups = GroupDiagnostics(filtered, groupBy);
+			return new ListDiagnosticsResult(filtered.Length, groupBy, groups);
+		}
+
+		[McpServerTool(Name = "get_diagnostics")]
+		[Description("List the individual occurrences (file, line, column, message) for a single rule id, paged.")]
+		public static async Task<GetDiagnosticsResult> GetDiagnosticsAsync(
+			SessionManager sessions,
+			[Description("Session id from open_analysis.")] string sessionId,
+			[Description("The rule id to list occurrences for.")] string ruleId,
+			[Description("Number of occurrences to skip (for paging).")] int skip = 0,
+			[Description("Maximum number of occurrences to return.")] int take = 50,
+			CancellationToken cancellationToken = default)
+		{
+			var session = Get(sessions, sessionId);
+			var ids = ImmutableHashSet.Create(StringComparer.Ordinal, ruleId);
+			var diagnostics = await session.AnalyzeAsync(ids, cancellationToken).ConfigureAwait(false);
+
+			var occurrences = diagnostics
+				.OrderBy(d => d.FilePath, StringComparer.OrdinalIgnoreCase)
+				.ThenBy(d => d.StartLine)
+				.ThenBy(d => d.StartColumn)
+				.Skip(Math.Max(0, skip))
+				.Take(Math.Max(0, take))
+				.Select(d => new DiagnosticOccurrence(d.Id, d.Severity, d.Message, d.ProjectName, d.FilePath, d.StartLine, d.StartColumn, d.EndLine, d.EndColumn, d.HasCodeFix))
+				.ToArray();
+
+			return new GetDiagnosticsResult(ruleId, diagnostics.Length, skip, take, occurrences);
+		}
+
+		[McpServerTool(Name = "apply_fixes")]
+		[Description("Apply fix-all code fixes for the given rule ids until no further changes are made, writing the " +
+			"results to disk. Only rules that have a code fix provider can be fixed. Returns what changed and what remains.")]
+		public static async Task<ApplyFixesResult> ApplyFixesAsync(
+			SessionManager sessions,
+			[Description("Session id from open_analysis.")] string sessionId,
+			[Description("';'-separated rule ids to fix.")] string ruleIds,
+			CancellationToken cancellationToken = default)
+		{
+			var session = Get(sessions, sessionId);
+			var ids = ParseIds(ruleIds);
+
+			if (ids == null || ids.Count == 0)
+			{
+				throw new ArgumentException("At least one rule id is required.", nameof(ruleIds));
+			}
+
+			var result = await session.ApplyFixesAsync(ids, cancellationToken).ConfigureAwait(false);
+			return new ApplyFixesResult(result.OperationsApplied, result.ChangedFiles, result.RemainingByRule);
+		}
+
+		[McpServerTool(Name = "close_analysis")]
+		[Description("Close an analysis session and release its workspace from memory.")]
+		public static CloseResult CloseAnalysis(
+			SessionManager sessions,
+			[Description("Session id from open_analysis.")] string sessionId)
+		{
+			if (sessions.Remove(sessionId, out var session))
+			{
+				session.Dispose();
+				return new CloseResult(true, "Session closed.");
+			}
+
+			return new CloseResult(false, $"No open session with id '{sessionId}'.");
+		}
+
+		static AnalysisSession Get(SessionManager sessions, string sessionId)
+		{
+			if (!sessions.TryGet(sessionId, out var session))
+			{
+				throw new ArgumentException($"No open session with id '{sessionId}'. Call open_analysis first.", nameof(sessionId));
+			}
+
+			return session;
+		}
+
+		static ImmutableHashSet<string>? ParseIds(string? ruleIds)
+		{
+			if (string.IsNullOrWhiteSpace(ruleIds))
+			{
+				return null;
+			}
+
+			return ruleIds
+				.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+				.ToImmutableHashSet(StringComparer.Ordinal);
+		}
+
+		static Func<string, bool>? BuildFilter(string? filter)
+		{
+			if (string.IsNullOrWhiteSpace(filter))
+			{
+				return null;
+			}
+
+			var regex = new Regex(filter, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+			return regex.IsMatch;
+		}
+
+		static bool IsProjectOrSolutionFile(string path)
+			=> path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)
+				|| path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase)
+				|| path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase);
+
+		static ImmutableArray<DiagnosticInfo> ApplyMinSeverity(ImmutableArray<DiagnosticInfo> diagnostics, string? minSeverity)
+		{
+			if (string.IsNullOrWhiteSpace(minSeverity))
+			{
+				return diagnostics;
+			}
+
+			var threshold = SeverityRank(minSeverity);
+			return diagnostics.Where(d => SeverityRank(d.Severity) >= threshold).ToImmutableArray();
+		}
+
+		static int SeverityRank(string severity) => severity.ToUpperInvariant() switch
+		{
+			"ERROR" => 3,
+			"WARNING" => 2,
+			"INFO" => 1,
+			_ => 0,
+		};
+
+		static IReadOnlyList<DiagnosticGroup> GroupDiagnostics(ImmutableArray<DiagnosticInfo> diagnostics, string groupBy)
+		{
+			switch ((groupBy ?? "rule").ToUpperInvariant())
+			{
+				case "SEVERITY":
+					return diagnostics
+						.GroupBy(d => d.Severity, StringComparer.OrdinalIgnoreCase)
+						.Select(g => new DiagnosticGroup(g.Key, null, g.Key, null, g.Count(), g.Any(d => d.HasCodeFix)))
+						.OrderByDescending(g => SeverityRank(g.Key))
+						.ToArray();
+
+				case "PROJECT":
+					return diagnostics
+						.GroupBy(d => d.ProjectName, StringComparer.OrdinalIgnoreCase)
+						.Select(g => new DiagnosticGroup(g.Key, null, null, null, g.Count(), g.Any(d => d.HasCodeFix)))
+						.OrderByDescending(g => g.Count)
+						.ToArray();
+
+				case "FIXABILITY":
+					return diagnostics
+						.GroupBy(d => d.HasCodeFix)
+						.Select(g => new DiagnosticGroup(g.Key ? "fixable" : "not-fixable", null, null, null, g.Count(), g.Key))
+						.OrderByDescending(g => g.HasCodeFix)
+						.ToArray();
+
+				default:
+					return diagnostics
+						.GroupBy(d => d.Id, StringComparer.Ordinal)
+						.Select(g =>
+						{
+							var first = g.First();
+							return new DiagnosticGroup(g.Key, first.Title, first.Severity, first.Category, g.Count(), first.HasCodeFix);
+						})
+						.OrderByDescending(g => g.Count)
+						.ThenBy(g => g.Key, StringComparer.Ordinal)
+						.ToArray();
+			}
+		}
+	}
+}

--- a/src/WTG.BulkAnalysis.Mcp/Contracts.cs
+++ b/src/WTG.BulkAnalysis.Mcp/Contracts.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace WTG.BulkAnalysis.Mcp
+{
+	/// <summary>Result of opening an analysis session.</summary>
+	public sealed record OpenResult(
+		string? SessionId,
+		string Target,
+		IReadOnlyList<string> Projects,
+		IReadOnlyList<string>? CandidateSolutions,
+		string Message);
+
+	/// <summary>A grouped summary of diagnostics.</summary>
+	public sealed record DiagnosticGroup(
+		string Key,
+		string? Title,
+		string? Severity,
+		string? Category,
+		int Count,
+		bool HasCodeFix);
+
+	/// <summary>Result of listing/grouping diagnostics.</summary>
+	public sealed record ListDiagnosticsResult(
+		int Total,
+		string GroupBy,
+		IReadOnlyList<DiagnosticGroup> Groups);
+
+	/// <summary>A single diagnostic occurrence.</summary>
+	public sealed record DiagnosticOccurrence(
+		string Id,
+		string Severity,
+		string Message,
+		string ProjectName,
+		string? FilePath,
+		int StartLine,
+		int StartColumn,
+		int EndLine,
+		int EndColumn,
+		bool HasCodeFix);
+
+	/// <summary>Paged list of individual diagnostic occurrences for a rule.</summary>
+	public sealed record GetDiagnosticsResult(
+		string RuleId,
+		int Total,
+		int Skip,
+		int Take,
+		IReadOnlyList<DiagnosticOccurrence> Occurrences);
+
+	/// <summary>Result of applying fixes.</summary>
+	public sealed record ApplyFixesResult(
+		int OperationsApplied,
+		IReadOnlyList<string> ChangedFiles,
+		IReadOnlyDictionary<string, int> RemainingByRule);
+
+	/// <summary>Result of closing a session.</summary>
+	public sealed record CloseResult(
+		bool Closed,
+		string Message);
+}

--- a/src/WTG.BulkAnalysis.Mcp/McpLog.cs
+++ b/src/WTG.BulkAnalysis.Mcp/McpLog.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using WTG.BulkAnalysis.Core;
+using CoreLogLevel = WTG.BulkAnalysis.Core.LogLevel;
+using MsLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace WTG.BulkAnalysis.Mcp
+{
+	/// <summary>Bridges the engine's <see cref="ILog"/> to an <see cref="ILogger"/> (which writes to stderr).</summary>
+	public sealed class McpLog : ILog
+	{
+		public McpLog(ILogger logger)
+		{
+			this.logger = logger;
+		}
+
+		public void WriteFormatted(FormattableString message, CoreLogLevel level = CoreLogLevel.Normal)
+			=> logger.Log(Map(level), "{Message}", message.ToString(CultureInfo.CurrentCulture));
+
+		public void WriteLine(string message, CoreLogLevel level = CoreLogLevel.Normal)
+			=> logger.Log(Map(level), "{Message}", message);
+
+		public void WriteLine()
+		{
+		}
+
+		static MsLogLevel Map(CoreLogLevel level) => level switch
+		{
+			CoreLogLevel.Error => MsLogLevel.Error,
+			CoreLogLevel.Warning => MsLogLevel.Warning,
+			_ => MsLogLevel.Information,
+		};
+
+		readonly ILogger logger;
+	}
+}

--- a/src/WTG.BulkAnalysis.Mcp/Program.cs
+++ b/src/WTG.BulkAnalysis.Mcp/Program.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using WTG.BulkAnalysis.Mcp;
+
+// Analyzer assemblies are loaded with Assembly.LoadFile, which does not probe for an assembly's
+// dependencies. Resolve them from the requesting assembly's own directory so analyzers (e.g. those
+// that ship a separate *.Utils.dll) can run instead of throwing at execution time (reported as AD0001).
+AppDomain.CurrentDomain.AssemblyResolve += static (_, args) =>
+{
+	var requester = args.RequestingAssembly;
+
+	if (requester == null || string.IsNullOrEmpty(requester.Location))
+	{
+		return null;
+	}
+
+	var directory = Path.GetDirectoryName(requester.Location);
+	var name = new AssemblyName(args.Name).Name;
+
+	if (directory == null || name == null)
+	{
+		return null;
+	}
+
+	var candidate = Path.Combine(directory, name + ".dll");
+	return File.Exists(candidate) ? Assembly.LoadFile(candidate) : null;
+};
+
+// MSBuildWorkspace (Roslyn 4.7) loads MSBuild in-process, so register the installed SDK's MSBuild
+// before any project is opened. (4.7 is used deliberately: 4.8+ moved to an out-of-process BuildHost
+// that fails to connect when hosted under an stdio server.)
+if (!MSBuildLocator.IsRegistered)
+{
+	MSBuildLocator.RegisterDefaults();
+}
+
+await Server.RunAsync(args).ConfigureAwait(false);
+
+namespace WTG.BulkAnalysis.Mcp
+{
+	static class Server
+	{
+		public static async Task RunAsync(string[] args)
+		{
+			var builder = Host.CreateApplicationBuilder(args);
+
+			// stdout is reserved for the MCP protocol over stdio; route all logging to stderr.
+			builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+			builder.Services.AddSingleton<SessionManager>();
+			builder.Services
+				.AddMcpServer()
+				.WithStdioServerTransport()
+				.WithToolsFromAssembly();
+
+			using var host = builder.Build();
+			await host.RunAsync().ConfigureAwait(false);
+		}
+	}
+}

--- a/src/WTG.BulkAnalysis.Mcp/Program.cs
+++ b/src/WTG.BulkAnalysis.Mcp/Program.cs
@@ -1,40 +1,16 @@
-using System;
-using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using WTG.BulkAnalysis.Core;
 using WTG.BulkAnalysis.Mcp;
 
-// Analyzer assemblies are loaded with Assembly.LoadFile, which does not probe for an assembly's
-// dependencies. Resolve them from the requesting assembly's own directory so analyzers (e.g. those
-// that ship a separate *.Utils.dll) can run instead of throwing at execution time (reported as AD0001).
-AppDomain.CurrentDomain.AssemblyResolve += static (_, args) =>
-{
-	var requester = args.RequestingAssembly;
+// Resolve analyzer dependencies (loaded via Assembly.LoadFile) from their own directory.
+AnalyzerAssemblyResolver.Register();
 
-	if (requester == null || string.IsNullOrEmpty(requester.Location))
-	{
-		return null;
-	}
-
-	var directory = Path.GetDirectoryName(requester.Location);
-	var name = new AssemblyName(args.Name).Name;
-
-	if (directory == null || name == null)
-	{
-		return null;
-	}
-
-	var candidate = Path.Combine(directory, name + ".dll");
-	return File.Exists(candidate) ? Assembly.LoadFile(candidate) : null;
-};
-
-// MSBuildWorkspace (Roslyn 4.7) loads MSBuild in-process, so register the installed SDK's MSBuild
-// before any project is opened. (4.7 is used deliberately: 4.8+ moved to an out-of-process BuildHost
-// that fails to connect when hosted under an stdio server.)
+// Register the installed .NET SDK's MSBuild before any project is opened so MSBuildWorkspace
+// (Roslyn 5.x) can locate it.
 if (!MSBuildLocator.IsRegistered)
 {
 	MSBuildLocator.RegisterDefaults();
@@ -51,7 +27,7 @@ namespace WTG.BulkAnalysis.Mcp
 			var builder = Host.CreateApplicationBuilder(args);
 
 			// stdout is reserved for the MCP protocol over stdio; route all logging to stderr.
-			builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+			builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = Microsoft.Extensions.Logging.LogLevel.Trace);
 
 			builder.Services.AddSingleton<SessionManager>();
 			builder.Services

--- a/src/WTG.BulkAnalysis.Mcp/README.md
+++ b/src/WTG.BulkAnalysis.Mcp/README.md
@@ -1,0 +1,58 @@
+# Bulk Analysis Runner — MCP server
+
+A local [Model Context Protocol](https://modelcontextprotocol.io) server (stdio, `net10.0`) that
+lets LLMs / AI agents drive the Bulk Analysis Runner engine: **discover** analyzer diagnostics in a
+solution or project, **group / classify** them, and **apply code fixes** (including bulk FixAll
+operations) for the rules that have a code fix provider.
+
+It wraps the same `WTG.BulkAnalysis.Core` engine used by the CLI, exposed through a stateful
+in-memory `AnalysisSession` so the (expensive) workspace load happens once per session and is reused
+across calls.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `open_analysis` | Open a `.sln`/`.slnx`/`.csproj` (or a directory/branch with a `Build.xml`) and return a `sessionId`. Keeps the workspace + analyzers loaded in memory. |
+| `list_diagnostics` | Run all analyzers and return a grouped summary (`groupBy`: `rule` \| `severity` \| `project` \| `fixability`). Each group reports its `count` and `hasCodeFix` so you can see what is bulk-fixable. Optional `ruleIds` / `minSeverity` filters. |
+| `get_diagnostics` | List the individual occurrences (file, line, column, message) for one rule id, paged (`skip`/`take`). |
+| `apply_fixes` | Run FixAll for the given `;`-separated `ruleIds` until stable, writing changes to disk. Returns operations applied, changed files, and remaining counts. |
+| `close_analysis` | Dispose a session and release its workspace. |
+
+Re-running `list_diagnostics` re-analyzes the current (in-memory, fix-updated) workspace, so it
+reflects fixes applied in the same session. To pick up edits made outside the session, re-open it.
+
+## Running
+
+Build once, then point your MCP client at the built assembly (using a pre-built DLL keeps the
+protocol's stdout clean — avoid `dotnet run`, which writes build output to stdout):
+
+```bash
+dotnet build src/WTG.BulkAnalysis.Mcp -c Release
+```
+
+### Claude Code / VS Code (`.mcp.json` or `.vscode/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "bulk-analysis": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "/absolute/path/to/BulkAnalysisRunner/bin/Release/net10.0/BulkAnalysisRunner.Mcp.dll"
+      ]
+    }
+  }
+}
+```
+
+Then, from the agent: `open_analysis` on a solution, `list_diagnostics` to triage, `apply_fixes`
+for a fixable rule, and `close_analysis` when done.
+
+## Requirements & notes
+
+- **.NET 10 SDK** must be installed; the server registers the SDK's MSBuild via `MSBuildLocator`.
+- The engine pins **Roslyn 4.7.0** deliberately — it loads MSBuild in-process (4.8+ uses an
+  out-of-process BuildHost that does not connect under an stdio host) and runs Roslyn-4.x-era
+  analyzers without the AD0001 failures seen on the 5.x runtime. See the project memory for details.

--- a/src/WTG.BulkAnalysis.Mcp/README.md
+++ b/src/WTG.BulkAnalysis.Mcp/README.md
@@ -31,6 +31,11 @@ protocol's stdout clean — avoid `dotnet run`, which writes build output to std
 dotnet build src/WTG.BulkAnalysis.Mcp -c Release
 ```
 
+Builds use the artifacts output layout, so the server lands at
+`artifacts/bin/WTG.BulkAnalysis.Mcp/release/BulkAnalysisRunner.Mcp.dll` (each project gets its own
+isolated folder). For a standalone deployment, `dotnet publish src/WTG.BulkAnalysis.Mcp -c Release -o
+<dir>` produces a self-contained folder you can point at instead.
+
 ### Claude Code / VS Code (`.mcp.json` or `.vscode/mcp.json`)
 
 ```json
@@ -40,7 +45,7 @@ dotnet build src/WTG.BulkAnalysis.Mcp -c Release
       "type": "stdio",
       "command": "dotnet",
       "args": [
-        "/absolute/path/to/BulkAnalysisRunner/bin/Release/net10.0/BulkAnalysisRunner.Mcp.dll"
+        "/absolute/path/to/BulkAnalysisRunner/artifacts/bin/WTG.BulkAnalysis.Mcp/release/BulkAnalysisRunner.Mcp.dll"
       ]
     }
   }
@@ -53,6 +58,8 @@ for a fixable rule, and `close_analysis` when done.
 ## Requirements & notes
 
 - **.NET 10 SDK** must be installed; the server registers the SDK's MSBuild via `MSBuildLocator`.
-- The engine pins **Roslyn 4.7.0** deliberately — it loads MSBuild in-process (4.8+ uses an
-  out-of-process BuildHost that does not connect under an stdio host) and runs Roslyn-4.x-era
-  analyzers without the AD0001 failures seen on the 5.x runtime. See the project memory for details.
+- The engine uses **Roslyn 5.x** to match the .NET 10 SDK's compiler, so it parses modern C#
+  (e.g. C# 14). The reported diagnostics reflect the project's effective `.editorconfig` / global
+  analyzer config, and `list_diagnostics` defaults to Warning+ to match what a build surfaces.
+- First-time `open_analysis` on a large solution can take a few minutes (MSBuild evaluates the
+  project graph out-of-process); subsequent calls in the same session reuse the loaded workspace.

--- a/src/WTG.BulkAnalysis.Mcp/SessionManager.cs
+++ b/src/WTG.BulkAnalysis.Mcp/SessionManager.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Threading;
+using WTG.BulkAnalysis.Core;
+
+namespace WTG.BulkAnalysis.Mcp
+{
+	/// <summary>Owns the lifetime of the open <see cref="AnalysisSession"/> instances for the server.</summary>
+	public sealed class SessionManager : IDisposable
+	{
+		public string Add(AnalysisSession session)
+		{
+			var id = "session-" + Interlocked.Increment(ref counter).ToString(CultureInfo.InvariantCulture);
+			sessions[id] = session;
+			return id;
+		}
+
+		public bool TryGet(string id, [NotNullWhen(true)] out AnalysisSession? session)
+			=> sessions.TryGetValue(id, out session);
+
+		public bool Remove(string id, [NotNullWhen(true)] out AnalysisSession? session)
+			=> sessions.TryRemove(id, out session);
+
+		public void Dispose()
+		{
+			foreach (var session in sessions.Values)
+			{
+				session.Dispose();
+			}
+
+			sessions.Clear();
+		}
+
+		readonly ConcurrentDictionary<string, AnalysisSession> sessions = new ConcurrentDictionary<string, AnalysisSession>(StringComparer.Ordinal);
+		int counter;
+	}
+}

--- a/src/WTG.BulkAnalysis.Mcp/WTG.BulkAnalysis.Mcp.csproj
+++ b/src/WTG.BulkAnalysis.Mcp/WTG.BulkAnalysis.Mcp.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>BulkAnalysisRunner.Mcp</AssemblyName>
+    <RootNamespace>WTG.BulkAnalysis.Mcp</RootNamespace>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <!-- This is an executable host app; the repo-wide AllEnabledByDefault firehose (make-internal,
+         LoggerMessage delegates, etc.) adds no value here. Use the standard default analyzer set. -->
+    <AnalysisMode>Default</AnalysisMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WTG.BulkAnalysis.Core\WTG.BulkAnalysis.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
+++ b/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.BulkAnalysis.Test/AnalysisSessionTest.cs
+++ b/src/WTG.BulkAnalysis.Test/AnalysisSessionTest.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
+using WTG.BulkAnalysis.Core;
+
+namespace WTG.BulkAnalysis.Test;
+
+[NonParallelizable]
+public class AnalysisSessionTest
+{
+	[Test]
+	public async Task ReportsAFixableRuleInAModernProject()
+	{
+		// The fixture uses a C# 12 collection expression; if the engine's Roslyn were too old to parse
+		// it, analysis would be disrupted and CA1822 would not be found here.
+		var path = CreateFixture(suppressCA1822: false);
+
+		var diagnostics = await AnalyzeAsync(path).ConfigureAwait(false);
+
+		var ca1822 = diagnostics.Where(d => d.Id == "CA1822").ToArray();
+		Assert.That(ca1822, Is.Not.Empty, "Expected CA1822 to be reported in the modern fixture project.");
+		Assert.That(ca1822.All(d => d.HasCodeFix), Is.True);
+	}
+
+	[Test]
+	public async Task HonoursGlobalAnalyzerConfigSuppression()
+	{
+		// Same fixture, but with a global analyzer config (as WTG.BuildConfiguration delivers one)
+		// suppressing CA1822. It must not be reported.
+		var path = CreateFixture(suppressCA1822: true);
+
+		var diagnostics = await AnalyzeAsync(path).ConfigureAwait(false);
+
+		Assert.That(diagnostics.Any(d => d.Id == "CA1822"), Is.False, "CA1822 is suppressed by the global analyzer config and must not be reported.");
+	}
+
+	static async Task<ImmutableArray<DiagnosticInfo>> AnalyzeAsync(string projectPath)
+	{
+		var options = new AnalysisSessionOptions(projectPath, "Debug", loadDir: null, ImmutableArray<string>.Empty);
+		using var session = await AnalysisSession.OpenAsync(options, NullLog.Instance, CancellationToken.None).ConfigureAwait(false);
+		return await session.AnalyzeAsync(ImmutableHashSet.Create("CA1822"), CancellationToken.None).ConfigureAwait(false);
+	}
+
+	string CreateFixture(bool suppressCA1822)
+	{
+		var dir = Path.Combine(temporaryDirectory, suppressCA1822 ? "suppressed" : "plain");
+		Directory.CreateDirectory(dir);
+
+		var globalConfig = suppressCA1822
+			? "    <ItemGroup><GlobalAnalyzerConfigFiles Include=\"suppress.globalconfig\" /></ItemGroup>" + Environment.NewLine
+			: string.Empty;
+
+		File.WriteAllText(
+			Path.Combine(dir, "Fixture.csproj"),
+			"<Project Sdk=\"Microsoft.NET.Sdk\">" + Environment.NewLine +
+			"  <PropertyGroup>" + Environment.NewLine +
+			"    <TargetFramework>net8.0</TargetFramework>" + Environment.NewLine +
+			"    <Nullable>enable</Nullable>" + Environment.NewLine +
+			"    <AnalysisMode>AllEnabledByDefault</AnalysisMode>" + Environment.NewLine +
+			"    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>" + Environment.NewLine +
+			"  </PropertyGroup>" + Environment.NewLine +
+			globalConfig +
+			"</Project>" + Environment.NewLine);
+
+		File.WriteAllText(
+			Path.Combine(dir, "Calc.cs"),
+			"namespace Fixture;" + Environment.NewLine + Environment.NewLine +
+			"public class Calc" + Environment.NewLine +
+			"{" + Environment.NewLine +
+			"    static readonly int[] Numbers = [1, 2, 3];" + Environment.NewLine +
+			"    public int Total() => Numbers.Length;" + Environment.NewLine +
+			"}" + Environment.NewLine);
+
+		if (suppressCA1822)
+		{
+			File.WriteAllText(
+				Path.Combine(dir, "suppress.globalconfig"),
+				"is_global = true" + Environment.NewLine +
+				"dotnet_diagnostic.CA1822.severity = none" + Environment.NewLine);
+		}
+
+		Restore(dir);
+		return Path.Combine(dir, "Fixture.csproj");
+	}
+
+	static void Restore(string directory)
+	{
+		var info = new ProcessStartInfo("dotnet", "restore")
+		{
+			WorkingDirectory = directory,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+		};
+
+		using var process = Process.Start(info)!;
+		process.WaitForExit();
+		Assert.That(process.ExitCode, Is.Zero, "Fixture restore failed.");
+	}
+
+	[OneTimeSetUp]
+	public void OneTimeSetUp()
+	{
+		AnalyzerAssemblyResolver.Register();
+
+		if (!MSBuildLocator.IsRegistered)
+		{
+			MSBuildLocator.RegisterDefaults();
+		}
+	}
+
+	[SetUp]
+	public void Setup()
+	{
+		temporaryDirectory = Path.Combine(Path.GetTempPath(), "WTG.BulkAnalysis.AnalysisSessionTest", Guid.NewGuid().ToString());
+		Directory.CreateDirectory(temporaryDirectory);
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		if (temporaryDirectory != null)
+		{
+			Directory.Delete(temporaryDirectory, recursive: true);
+			temporaryDirectory = null!;
+		}
+	}
+
+	string temporaryDirectory = null!;
+
+	sealed class NullLog : ILog
+	{
+		public static readonly NullLog Instance = new NullLog();
+		public void WriteFormatted(FormattableString message, LogLevel level = LogLevel.Normal) { }
+		public void WriteLine(string message, LogLevel level = LogLevel.Normal) { }
+		public void WriteLine() { }
+	}
+}

--- a/src/WTG.BulkAnalysis.Test/AnalysisSessionTest.cs
+++ b/src/WTG.BulkAnalysis.Test/AnalysisSessionTest.cs
@@ -16,6 +16,11 @@ public class AnalysisSessionTest
 	[Test]
 	public async Task ReportsAFixableRuleInAModernProject()
 	{
+		// SDK analyzer injection for the fixture project only works when the host process is .NET Core/.NET 5+.
+		// On net472, MSBuildWorkspace does not populate AnalyzerReferences with the SDK's bundled analyzers,
+		// so the analysis returns no diagnostics and this assertion would trivially fail.
+		Assume.That(Environment.Version.Major >= 5, "SDK analyzer injection requires a .NET 5+ host process.");
+
 		// The fixture uses a C# 12 collection expression; if the engine's Roslyn were too old to parse
 		// it, analysis would be disrupted and CA1822 would not be found here.
 		var path = CreateFixture(suppressCA1822: false);

--- a/src/WTG.BulkAnalysis.Test/DiagnosticInfoTest.cs
+++ b/src/WTG.BulkAnalysis.Test/DiagnosticInfoTest.cs
@@ -1,0 +1,69 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using WTG.BulkAnalysis.Core;
+
+namespace WTG.BulkAnalysis.Test;
+
+public class DiagnosticInfoTest
+{
+	[Test]
+	public void MapsFieldsAndConvertsPositionsToOneBased()
+	{
+		// 'class C' starts at line 2, column 1 (0-based: line 1, char 0).
+		var tree = CSharpSyntaxTree.ParseText("\nclass C\n{\n}\n", path: "Widget.cs");
+		var start = tree.GetText().Lines[1].Start;
+		var location = Location.Create(tree, TextSpan.FromBounds(start, start + "class C".Length));
+
+		var descriptor = new DiagnosticDescriptor(
+			"WTG9999",
+			"The title",
+			"The message {0}",
+			"Naming",
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+
+		var diagnostic = Diagnostic.Create(descriptor, location, "detail");
+
+		var info = DiagnosticInfo.Create(diagnostic, "MyProject", hasCodeFix: true);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(info.Id, Is.EqualTo("WTG9999"));
+			Assert.That(info.Title, Is.EqualTo("The title"));
+			Assert.That(info.Message, Is.EqualTo("The message detail"));
+			Assert.That(info.Severity, Is.EqualTo("Warning"));
+			Assert.That(info.Category, Is.EqualTo("Naming"));
+			Assert.That(info.ProjectName, Is.EqualTo("MyProject"));
+			Assert.That(info.FilePath, Is.EqualTo("Widget.cs"));
+			Assert.That(info.HasCodeFix, Is.True);
+
+			// Roslyn reports 0-based positions; DiagnosticInfo exposes 1-based.
+			Assert.That(info.StartLine, Is.EqualTo(2));
+			Assert.That(info.StartColumn, Is.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public void RepresentsNonSourceDiagnosticsWithoutAFilePath()
+	{
+		var descriptor = new DiagnosticDescriptor(
+			"WTG0001",
+			"No location",
+			"No location",
+			"Usage",
+			DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		var diagnostic = Diagnostic.Create(descriptor, Location.None);
+
+		var info = DiagnosticInfo.Create(diagnostic, "MyProject", hasCodeFix: false);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(info.FilePath, Is.Null);
+			Assert.That(info.StartLine, Is.EqualTo(0));
+			Assert.That(info.HasCodeFix, Is.False);
+		});
+	}
+}

--- a/src/WTG.BulkAnalysis.Test/SolutionLocatorTest.cs
+++ b/src/WTG.BulkAnalysis.Test/SolutionLocatorTest.cs
@@ -12,12 +12,12 @@ public class SolutionLocatorTest
 		var solutions = SolutionLocator.Locate(temporaryDirectory, solutionFilter: null);
 
 		Assert.That(
-			solutions.ToArray(),
+			solutions.Select(Normalize).ToArray(),
 			Is.EqualTo(new[]
 			{
 				Path.Combine("src", "BulkAnalysisRunner.sln"),
 				"AnotherSln.sln",
-			}.Select(path => Path.Combine(temporaryDirectory, path))));
+			}.Select(path => Normalize(Path.Combine(temporaryDirectory, path)))));
 	}
 
 	[Test]
@@ -31,11 +31,11 @@ public class SolutionLocatorTest
 		var solutions = SolutionLocator.Locate(subdirPath, solutionFilter: null);
 
 		Assert.That(
-			solutions.ToArray(),
+			solutions.Select(Normalize).ToArray(),
 			Is.EqualTo(new[]
 			{
 				Path.Combine("src", "BulkAnalysisRunner.sln")
-			}.Select(path => Path.Combine(temporaryDirectory, path))));
+			}.Select(path => Normalize(Path.Combine(temporaryDirectory, path)))));
 	}
 
 	[Test]
@@ -64,6 +64,9 @@ public class SolutionLocatorTest
 		var solutions = SolutionLocator.Locate(subdirPath, solutionFilter: null);
 		Assert.That(solutions, Is.Empty);
 	}
+
+	// Build.xml uses Windows-style separators; normalise so the comparison is cross-platform.
+	static string Normalize(string path) => path.Replace('\\', '/');
 
 	IFileProvider fileProvider;
 	string temporaryDirectory;

--- a/src/WTG.BulkAnalysis.Test/WTG.BulkAnalysis.Test.csproj
+++ b/src/WTG.BulkAnalysis.Test/WTG.BulkAnalysis.Test.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <AnalysisMode>Default</AnalysisMode>
+    <!-- This project references Build.Locator to run MSBuildWorkspace in integration tests; MSBuildLocator
+         redirects MSBuild assemblies at runtime, so its assembly-copy check (MSBL001) is not relevant here. -->
+    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />


### PR DESCRIPTION
> [!WARNING]
> This PR is raw AI-generated code and is probably not yet fit for human consumption.

This PR adds a new executable, WTG.BulkAnalysisRunner.Mcp, which exposes a MCP server for LLM coding agents to find Roslyn Diagnostics in a workspace and apply the fixes.

The MCP server holds analysis sessions in-memory to avoid recomputing the whole project/solution on each request.

This is the result of a few back-and-forth sessions with Claude and includes a bunch of changes that should be their own outright prereqs, including upgrading dependencies, restructuring outputs, and changing target frameworks.

It's also quite possible that I mucked up line endings in this PR.