### PR TITLE
Update CodeAnalysis and MSBuild packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/setup-dotnet@v5
     - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v5
     - name: Build BulkAnalysisRunner
       run: dotnet build src --configuration ${{ matrix.configuration }}
     - name: Test BulkAnalysisRunner

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - uses: actions/setup-dotnet@v5
     - uses: actions/checkout@v2
     - name: Build BulkAnalysisRunner
       run: dotnet build src --configuration ${{ matrix.configuration }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,7 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\build\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <WTGAnalyzersWarnAll>true</WTGAnalyzersWarnAll>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
 
     <OutputPath>$(MSBuildThisFileDirectory)bin</OutputPath>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
 
     <Version>4.0.0.0</Version>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace WTG.BulkAnalysis.Core
 {
-	public abstract class AnalyzerCache
+	abstract class AnalyzerCache
 	{
 		protected AnalyzerCache(ImmutableHashSet<string> diagnosticIds, ILog log)
 		{

--- a/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
@@ -13,157 +13,230 @@ namespace WTG.BulkAnalysis.Core
 {
 	abstract class AnalyzerCache
 	{
-		public static AnalyzerCache Create(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList)
+		protected AnalyzerCache(ImmutableHashSet<string> diagnosticIds, ILog log)
+		{
+			this.diagnosticIds = diagnosticIds;
+			this.log = log;
+			analyzerFilter = a => a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
+			providerFilter = p => p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
+			providerLookup = new ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>>();
+			referenceCache = new ConcurrentDictionary<string, AnalyzerFileReference>(StringComparer.OrdinalIgnoreCase);
+			subscribed = new HashSet<AnalyzerFileReference>();
+		}
+
+		public static AnalyzerCache Create(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, ILog log)
 		{
 			if (loadList.Length > 0)
 			{
-				return new Explicit(diagnosticIds, loadDir, loadList);
+				return new Explicit(diagnosticIds, loadDir, loadList, log);
 			}
 			else
 			{
-				return new Implicit(diagnosticIds, loadDir);
+				return new Implicit(diagnosticIds, loadDir, log);
 			}
 		}
 
-		public abstract ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project);
-		public abstract ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project);
-
-		static IEnumerable<T> Get<T>(string assemblyPath, Predicate<T> filter)
+		public ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project)
 		{
-			var assembly = Assembly.LoadFile(assemblyPath);
+			var language = GetLanguage(project);
+			var builder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
 
-			foreach (var type in assembly.GetTypes())
+			foreach (var reference in GetReferences(project))
 			{
-				if (!type.IsAbstract && type.IsSubclassOf(typeof(T)))
-				{
-					var instance = (T)Activator.CreateInstance(type);
+				EnsureSubscribed(reference);
 
-					if (filter(instance))
+				// Let Roslyn's own analyzer loader resolve the analyzer and its dependencies.
+				// It binds the analyzer against the compiler assemblies already loaded in this
+				// process and reports unloadable analyzers via AnalyzerLoadFailed instead of
+				// throwing - so we never have to reflect over the assembly ourselves.
+				var analyzers = language == null
+					? reference.GetAnalyzersForAllLanguages()
+					: reference.GetAnalyzers(language);
+
+				foreach (var analyzer in analyzers)
+				{
+					if (analyzerFilter(analyzer))
 					{
-						yield return instance;
+						builder.Add(analyzer);
 					}
 				}
 			}
+
+			return builder.ToImmutable();
 		}
+
+		public ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project)
+		{
+			return ImmutableDictionary.ToImmutableDictionary(
+				from reference in GetReferences(project)
+				from provider in GetCodeFixProviders(reference)
+				from id in provider.FixableDiagnosticIds
+				where diagnosticIds.Contains(id)
+				group provider by id into g
+				select g,
+				x => x.Key,
+				x => x.ToImmutableList());
+		}
+
+		protected static IAnalyzerAssemblyLoader GetLoader(Project project)
+		{
+			// Reuse the assembly loader the workspace configured for this project's analyzer
+			// references, so assemblies we load from an alternate location share the same
+			// dependency-resolution behaviour.
+			foreach (var reference in project.AnalyzerReferences)
+			{
+				if (reference is AnalyzerFileReference fileReference)
+				{
+					return fileReference.AssemblyLoader;
+				}
+			}
+
+			return FallbackAssemblyLoader.Instance;
+		}
+
+		protected AnalyzerFileReference GetOrCreateReference(string path, IAnalyzerAssemblyLoader loader)
+			=> referenceCache.GetOrAdd(path, p => new AnalyzerFileReference(p, loader));
+
+		protected abstract IEnumerable<AnalyzerFileReference> GetReferences(Project project);
+		protected abstract string? GetLanguage(Project project);
+
+		ImmutableArray<CodeFixProvider> GetCodeFixProviders(AnalyzerFileReference reference)
+			=> providerLookup.GetOrAdd(reference.FullPath, key => LoadCodeFixProviders(reference));
+
+		ImmutableArray<CodeFixProvider> LoadCodeFixProviders(AnalyzerFileReference reference)
+		{
+			var builder = ImmutableArray.CreateBuilder<CodeFixProvider>();
+
+			// Roslyn has no discovery API for code fix providers, so we reflect over the
+			// assembly. We use the reference's own GetAssembly() rather than a fresh
+			// Assembly.LoadFile so the code fixes bind against the same, already-loaded copy
+			// Roslyn used for the analyzers.
+			foreach (var type in GetLoadableTypes(reference))
+			{
+				if (!type.IsAbstract && type.IsSubclassOf(typeof(CodeFixProvider)))
+				{
+					var provider = (CodeFixProvider)Activator.CreateInstance(type);
+
+					if (providerFilter(provider))
+					{
+						builder.Add(provider);
+					}
+				}
+			}
+
+			return builder.ToImmutable();
+		}
+
+		Type[] GetLoadableTypes(AnalyzerFileReference reference)
+		{
+			Assembly assembly;
+
+			try
+			{
+				assembly = reference.GetAssembly();
+			}
+			catch (Exception ex)
+			{
+				log.WriteFormatted($"  - Unable to load code fixes from '{reference.FullPath}': {ex.Message}", LogLevel.Warning);
+				return Array.Empty<Type>();
+			}
+
+			try
+			{
+				return assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException ex)
+			{
+				// A provider whose dependencies can't be resolved appears as a null entry here;
+				// keep the types that did load. This mirrors how Roslyn's AnalyzerFileReference
+				// tolerates partial load failures when enumerating analyzers.
+				return ex.Types.Where(t => t != null).ToArray()!;
+			}
+		}
+
+		void EnsureSubscribed(AnalyzerFileReference reference)
+		{
+			if (subscribed.Add(reference))
+			{
+				reference.AnalyzerLoadFailed += OnAnalyzerLoadFailed;
+			}
+		}
+
+		void OnAnalyzerLoadFailed(object? sender, AnalyzerLoadFailureEventArgs e)
+		{
+			var path = (sender as AnalyzerFileReference)?.FullPath;
+			var detail = string.IsNullOrEmpty(e.Message) ? e.Exception?.Message : e.Message;
+			var suffix = string.IsNullOrEmpty(detail) ? string.Empty : $": {detail}";
+			log.WriteFormatted($"  - Skipping an analyzer in '{path}' ({e.ErrorCode}){suffix}", LogLevel.Warning);
+		}
+
+		readonly ImmutableHashSet<string> diagnosticIds;
+		readonly ILog log;
+		readonly Predicate<DiagnosticAnalyzer> analyzerFilter;
+		readonly Predicate<CodeFixProvider> providerFilter;
+		readonly ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>> providerLookup;
+		readonly ConcurrentDictionary<string, AnalyzerFileReference> referenceCache;
+		readonly HashSet<AnalyzerFileReference> subscribed;
 
 		sealed class Implicit : AnalyzerCache
 		{
-			public Implicit(ImmutableHashSet<string> diagnosticIds, string loadDir)
+			public Implicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ILog log)
+				: base(diagnosticIds, log)
 			{
 				this.loadDir = loadDir;
-				analyzerFilter = a => a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
-				providerFilter = p => p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
-				analyzerLookup = new ConcurrentDictionary<string, ImmutableArray<DiagnosticAnalyzer>>();
-				providerLookup = new ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>>();
 			}
 
-			public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project)
-			{
-				var paths = GetAnalyzerRefs(project);
+			protected override string? GetLanguage(Project project) => project.Language;
 
-				if (!string.IsNullOrEmpty(loadDir))
+			protected override IEnumerable<AnalyzerFileReference> GetReferences(Project project)
+			{
+				if (string.IsNullOrEmpty(loadDir))
 				{
-					paths = Remap(paths, loadDir);
+					return project.AnalyzerReferences.OfType<AnalyzerFileReference>();
 				}
 
-				return ImmutableArray.CreateRange(
-					from analyzerRef in paths
-					from analyzer in GetAnalyzers(analyzerRef)
-					select analyzer);
+				return Remap(project, loadDir);
 			}
 
-			public override ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project)
+			IEnumerable<AnalyzerFileReference> Remap(Project project, string loadDir)
 			{
-				var paths = GetAnalyzerRefs(project);
-
-				if (!string.IsNullOrEmpty(loadDir))
-				{
-					paths = Remap(paths, loadDir);
-				}
-
-				return ImmutableDictionary.ToImmutableDictionary(
-					from analyzerRef in paths
-					from codeFixProvider in GetCodeFixProviders(analyzerRef)
-					from diagnosticId in codeFixProvider.FixableDiagnosticIds
-					group codeFixProvider by diagnosticId into g
-					select g,
-					x => x.Key,
-					x => x.ToImmutableList());
-			}
-
-			ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string assemblyName) => GetCached(assemblyName, analyzerLookup, analyzerFilter);
-			ImmutableArray<CodeFixProvider> GetCodeFixProviders(string assemblyName) => GetCached(assemblyName, providerLookup, providerFilter);
-
-			static ImmutableArray<T> GetCached<T>(string assemblyName, ConcurrentDictionary<string, ImmutableArray<T>> lookup, Predicate<T> filter)
-			{
-				if (!lookup.TryGetValue(assemblyName, out var result))
-				{
-					result = Get(assemblyName, filter).ToImmutableArray();
-					result = lookup.GetOrAdd(assemblyName, result);
-				}
-
-				return result;
-			}
-
-			static IEnumerable<string> GetAnalyzerRefs(Project project)
-			{
-				var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+				var loader = GetLoader(project);
 
 				foreach (var reference in project.AnalyzerReferences)
 				{
-					if (!string.IsNullOrEmpty(reference.FullPath))
+					if (string.IsNullOrEmpty(reference.FullPath))
 					{
-						result.Add(reference.FullPath!);
+						continue;
 					}
-				}
 
-				return result;
-			}
-
-			static IEnumerable<string> Remap(IEnumerable<string> source, string loadDir)
-			{
-				foreach (var item in source)
-				{
-					var proposal = Path.Combine(loadDir, Path.GetFileName(item));
+					var proposal = Path.Combine(loadDir, Path.GetFileName(reference.FullPath));
 
 					if (File.Exists(proposal))
 					{
-						yield return proposal;
+						yield return GetOrCreateReference(proposal, loader);
 					}
 				}
 			}
 
 			readonly string loadDir;
-			readonly Predicate<DiagnosticAnalyzer> analyzerFilter;
-			readonly Predicate<CodeFixProvider> providerFilter;
-			readonly ConcurrentDictionary<string, ImmutableArray<DiagnosticAnalyzer>> analyzerLookup;
-			readonly ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>> providerLookup;
 		}
 
 		sealed class Explicit : AnalyzerCache
 		{
-			public Explicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList)
+			public Explicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, ILog log)
+				: base(diagnosticIds, log)
 			{
-				Predicate<DiagnosticAnalyzer> analyzerFilter = a => a.SupportedDiagnostics.Any(x => diagnosticIds.Contains(x.Id));
-				Predicate<CodeFixProvider> providerFilter = p => p.FixableDiagnosticIds.Any(diagnosticIds.Contains);
-
-				var paths = PrefixPaths(loadDir, loadList);
-
-				analyzers = paths.SelectMany(x => Get(x, analyzerFilter)).ToImmutableArray();
-
-				providers = ImmutableDictionary.ToImmutableDictionary(
-					from path in paths
-					from provider in Get(path, providerFilter)
-					from id in provider.FixableDiagnosticIds
-					where diagnosticIds.Contains(id)
-					group provider by id into g
-					select g,
-					x => x.Key,
-					x => x.ToImmutableList());
+				paths = PrefixPaths(loadDir, loadList).ToImmutableArray();
 			}
 
-			public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project) => analyzers;
-			public override ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project) => providers;
+			// No project context, so ask each reference for analyzers across all languages.
+			protected override string? GetLanguage(Project project) => null;
+
+			protected override IEnumerable<AnalyzerFileReference> GetReferences(Project project)
+			{
+				var loader = GetLoader(project);
+				return paths.Select(path => GetOrCreateReference(path, loader));
+			}
 
 			static IEnumerable<string> PrefixPaths(string loadDir, ImmutableArray<string> loadList)
 			{
@@ -177,8 +250,18 @@ namespace WTG.BulkAnalysis.Core
 				return paths;
 			}
 
-			readonly ImmutableArray<DiagnosticAnalyzer> analyzers;
-			readonly ImmutableDictionary<string, ImmutableList<CodeFixProvider>> providers;
+			readonly ImmutableArray<string> paths;
+		}
+
+		sealed class FallbackAssemblyLoader : IAnalyzerAssemblyLoader
+		{
+			public static readonly FallbackAssemblyLoader Instance = new FallbackAssemblyLoader();
+
+			public void AddDependencyLocation(string fullPath)
+			{
+			}
+
+			public Assembly LoadFromPath(string fullPath) => Assembly.LoadFrom(fullPath);
 		}
 	}
 }

--- a/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
@@ -199,9 +199,6 @@ namespace WTG.BulkAnalysis.Core
 			public Explicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, ILog log)
 				: base(diagnosticIds, log)
 			{
-				// The explicit load list stands alone rather than tracking a project, so resolve it up
-				// front. There is no project reference to borrow a loader from, and no project language,
-				// so use the fallback loader and ask each reference for analyzers across all languages.
 				var references = PrefixPaths(loadDir, loadList)
 					.Select(path => GetOrCreateReference(path, FallbackAssemblyLoader.Instance))
 					.ToImmutableArray();

--- a/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace WTG.BulkAnalysis.Core
 {
-	abstract class AnalyzerCache
+	public abstract class AnalyzerCache
 	{
 		protected AnalyzerCache(ImmutableHashSet<string> diagnosticIds, ILog log)
 		{
@@ -23,6 +23,14 @@ namespace WTG.BulkAnalysis.Core
 			referenceCache = new ConcurrentDictionary<string, AnalyzerFileReference>(StringComparer.OrdinalIgnoreCase);
 			subscribed = new HashSet<AnalyzerFileReference>();
 		}
+
+		readonly ImmutableHashSet<string> diagnosticIds;
+		readonly ILog log;
+		readonly Predicate<DiagnosticAnalyzer> analyzerFilter;
+		readonly Predicate<CodeFixProvider> providerFilter;
+		readonly ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>> providerLookup;
+		readonly ConcurrentDictionary<string, AnalyzerFileReference> referenceCache;
+		readonly HashSet<AnalyzerFileReference> subscribed;
 
 		public static AnalyzerCache Create(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, ILog log)
 		{
@@ -45,21 +53,11 @@ namespace WTG.BulkAnalysis.Core
 			{
 				EnsureSubscribed(reference);
 
-				// Let Roslyn's own analyzer loader resolve the analyzer and its dependencies.
-				// It binds the analyzer against the compiler assemblies already loaded in this
-				// process and reports unloadable analyzers via AnalyzerLoadFailed instead of
-				// throwing - so we never have to reflect over the assembly ourselves.
-				var analyzers = language == null
-					? reference.GetAnalyzersForAllLanguages()
-					: reference.GetAnalyzers(language);
+				var analyzers = language is not null
+					? reference.GetAnalyzers(language)
+					: reference.GetAnalyzersForAllLanguages();
 
-				foreach (var analyzer in analyzers)
-				{
-					if (analyzerFilter(analyzer))
-					{
-						builder.Add(analyzer);
-					}
-				}
+				builder.AddRange(analyzers.Where(a => analyzerFilter(a)));
 			}
 
 			return builder.ToImmutable();
@@ -107,10 +105,6 @@ namespace WTG.BulkAnalysis.Core
 		{
 			var builder = ImmutableArray.CreateBuilder<CodeFixProvider>();
 
-			// Roslyn has no discovery API for code fix providers, so we reflect over the
-			// assembly. We use the reference's own GetAssembly() rather than a fresh
-			// Assembly.LoadFile so the code fixes bind against the same, already-loaded copy
-			// Roslyn used for the analyzers.
 			foreach (var type in GetLoadableTypes(reference))
 			{
 				if (!type.IsAbstract && type.IsSubclassOf(typeof(CodeFixProvider)))
@@ -127,7 +121,7 @@ namespace WTG.BulkAnalysis.Core
 			return builder.ToImmutable();
 		}
 
-		Type[] GetLoadableTypes(AnalyzerFileReference reference)
+		IEnumerable<Type> GetLoadableTypes(AnalyzerFileReference reference)
 		{
 			Assembly assembly;
 
@@ -138,7 +132,7 @@ namespace WTG.BulkAnalysis.Core
 			catch (Exception ex)
 			{
 				log.WriteFormatted($"  - Unable to load code fixes from '{reference.FullPath}': {ex.Message}", LogLevel.Warning);
-				return Array.Empty<Type>();
+				return [];
 			}
 
 			try
@@ -169,14 +163,6 @@ namespace WTG.BulkAnalysis.Core
 			var suffix = string.IsNullOrEmpty(detail) ? string.Empty : $": {detail}";
 			log.WriteFormatted($"  - Skipping an analyzer in '{path}' ({e.ErrorCode}){suffix}", LogLevel.Warning);
 		}
-
-		readonly ImmutableHashSet<string> diagnosticIds;
-		readonly ILog log;
-		readonly Predicate<DiagnosticAnalyzer> analyzerFilter;
-		readonly Predicate<CodeFixProvider> providerFilter;
-		readonly ConcurrentDictionary<string, ImmutableArray<CodeFixProvider>> providerLookup;
-		readonly ConcurrentDictionary<string, AnalyzerFileReference> referenceCache;
-		readonly HashSet<AnalyzerFileReference> subscribed;
 
 		sealed class Implicit : AnalyzerCache
 		{

--- a/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
+++ b/src/WTG.BulkAnalysis.Core/Internal/AnalyzerCache.cs
@@ -44,12 +44,14 @@ namespace WTG.BulkAnalysis.Core
 			}
 		}
 
-		public ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project)
+		public abstract ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project);
+		public abstract ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project);
+
+		protected ImmutableArray<DiagnosticAnalyzer> CollectAnalyzers(IEnumerable<AnalyzerFileReference> references, string? language)
 		{
-			var language = GetLanguage(project);
 			var builder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
 
-			foreach (var reference in GetReferences(project))
+			foreach (var reference in references)
 			{
 				EnsureSubscribed(reference);
 
@@ -63,10 +65,10 @@ namespace WTG.BulkAnalysis.Core
 			return builder.ToImmutable();
 		}
 
-		public ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project)
+		protected ImmutableDictionary<string, ImmutableList<CodeFixProvider>> CollectCodeFixProviders(IEnumerable<AnalyzerFileReference> references)
 		{
 			return ImmutableDictionary.ToImmutableDictionary(
-				from reference in GetReferences(project)
+				from reference in references
 				from provider in GetCodeFixProviders(reference)
 				from id in provider.FixableDiagnosticIds
 				where diagnosticIds.Contains(id)
@@ -76,27 +78,8 @@ namespace WTG.BulkAnalysis.Core
 				x => x.ToImmutableList());
 		}
 
-		protected static IAnalyzerAssemblyLoader GetLoader(Project project)
-		{
-			// Reuse the assembly loader the workspace configured for this project's analyzer
-			// references, so assemblies we load from an alternate location share the same
-			// dependency-resolution behaviour.
-			foreach (var reference in project.AnalyzerReferences)
-			{
-				if (reference is AnalyzerFileReference fileReference)
-				{
-					return fileReference.AssemblyLoader;
-				}
-			}
-
-			return FallbackAssemblyLoader.Instance;
-		}
-
 		protected AnalyzerFileReference GetOrCreateReference(string path, IAnalyzerAssemblyLoader loader)
 			=> referenceCache.GetOrAdd(path, p => new AnalyzerFileReference(p, loader));
-
-		protected abstract IEnumerable<AnalyzerFileReference> GetReferences(Project project);
-		protected abstract string? GetLanguage(Project project);
 
 		ImmutableArray<CodeFixProvider> GetCodeFixProviders(AnalyzerFileReference reference)
 			=> providerLookup.GetOrAdd(reference.FullPath, key => LoadCodeFixProviders(reference));
@@ -172,9 +155,13 @@ namespace WTG.BulkAnalysis.Core
 				this.loadDir = loadDir;
 			}
 
-			protected override string? GetLanguage(Project project) => project.Language;
+			public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project)
+				=> CollectAnalyzers(GetReferences(project), project.Language);
 
-			protected override IEnumerable<AnalyzerFileReference> GetReferences(Project project)
+			public override ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project)
+				=> CollectCodeFixProviders(GetReferences(project));
+
+			IEnumerable<AnalyzerFileReference> GetReferences(Project project)
 			{
 				if (string.IsNullOrEmpty(loadDir))
 				{
@@ -186,9 +173,7 @@ namespace WTG.BulkAnalysis.Core
 
 			IEnumerable<AnalyzerFileReference> Remap(Project project, string loadDir)
 			{
-				var loader = GetLoader(project);
-
-				foreach (var reference in project.AnalyzerReferences)
+				foreach (var reference in project.AnalyzerReferences.OfType<AnalyzerFileReference>())
 				{
 					if (string.IsNullOrEmpty(reference.FullPath))
 					{
@@ -199,6 +184,8 @@ namespace WTG.BulkAnalysis.Core
 
 					if (File.Exists(proposal))
 					{
+						var loader = reference.AssemblyLoader;
+						loader.AddDependencyLocation(proposal);
 						yield return GetOrCreateReference(proposal, loader);
 					}
 				}
@@ -212,17 +199,19 @@ namespace WTG.BulkAnalysis.Core
 			public Explicit(ImmutableHashSet<string> diagnosticIds, string loadDir, ImmutableArray<string> loadList, ILog log)
 				: base(diagnosticIds, log)
 			{
-				paths = PrefixPaths(loadDir, loadList).ToImmutableArray();
+				// The explicit load list stands alone rather than tracking a project, so resolve it up
+				// front. There is no project reference to borrow a loader from, and no project language,
+				// so use the fallback loader and ask each reference for analyzers across all languages.
+				var references = PrefixPaths(loadDir, loadList)
+					.Select(path => GetOrCreateReference(path, FallbackAssemblyLoader.Instance))
+					.ToImmutableArray();
+
+				analyzers = CollectAnalyzers(references, language: null);
+				providers = CollectCodeFixProviders(references);
 			}
 
-			// No project context, so ask each reference for analyzers across all languages.
-			protected override string? GetLanguage(Project project) => null;
-
-			protected override IEnumerable<AnalyzerFileReference> GetReferences(Project project)
-			{
-				var loader = GetLoader(project);
-				return paths.Select(path => GetOrCreateReference(path, loader));
-			}
+			public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(Project project) => analyzers;
+			public override ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixProviders(Project project) => providers;
 
 			static IEnumerable<string> PrefixPaths(string loadDir, ImmutableArray<string> loadList)
 			{
@@ -236,7 +225,8 @@ namespace WTG.BulkAnalysis.Core
 				return paths;
 			}
 
-			readonly ImmutableArray<string> paths;
+			readonly ImmutableArray<DiagnosticAnalyzer> analyzers;
+			readonly ImmutableDictionary<string, ImmutableList<CodeFixProvider>> providers;
 		}
 
 		sealed class FallbackAssemblyLoader : IAnalyzerAssemblyLoader

--- a/src/WTG.BulkAnalysis.Core/Processor.cs
+++ b/src/WTG.BulkAnalysis.Core/Processor.cs
@@ -31,7 +31,7 @@ namespace WTG.BulkAnalysis.Core
 
 			var counter = 0;
 			var numSolutions = context.SolutionPaths.Length;
-			var cache = AnalyzerCache.Create(context.RuleIds, context.LoadDir, context.LoadList);
+			var cache = AnalyzerCache.Create(context.RuleIds, context.LoadDir, context.LoadList, context.Log);
 
 			foreach (var solutionPath in context.SolutionPaths)
 			{

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -5,13 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="WTG.BulkAnalysis.Test" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
-    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -6,10 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="WTG.BulkAnalysis.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">

--- a/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
+++ b/src/WTG.BulkAnalysis.Core/WTG.BulkAnalysis.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="WTG.BulkAnalysis.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">

--- a/src/WTG.BulkAnalysis.Runner/App.config
+++ b/src/WTG.BulkAnalysis.Runner/App.config
@@ -8,58 +8,50 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces.Desktop" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.7.0.0-4.4.0.0" newVersion="4.4.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
 			</dependentAssembly>
 
 			<dependentAssembly>
 				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="1.0.27.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
 			</dependentAssembly>
 
 			<dependentAssembly>
 				<assemblyIdentity name="System.Composition.AttributedModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="1.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Composition.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="1.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Composition.TypedParts" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="1.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
 			</dependentAssembly>
 
 			<dependentAssembly>
 				<assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="1.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/src/WTG.BulkAnalysis.Runner/Program.cs
+++ b/src/WTG.BulkAnalysis.Runner/Program.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,8 +20,6 @@ namespace WTG.BulkAnalysis.Runner
 			{
 				return;
 			}
-
-			AppDomain.CurrentDomain.AssemblyResolve += OnAppDomainAssemblyResolve;
 
 			using var cts = new CancellationTokenSource();
 
@@ -139,19 +135,6 @@ namespace WTG.BulkAnalysis.Runner
 			}
 
 			return ((Parsed<CommandLineArgs>)parseResult).Value;
-		}
-
-		static Assembly? OnAppDomainAssemblyResolve(object sender, ResolveEventArgs args)
-		{
-			if (args.RequestingAssembly == null)
-			{
-				return null;
-			}
-
-			var requesterPath = new Uri(args.RequestingAssembly.CodeBase, UriKind.Absolute).LocalPath;
-			var directory = Path.GetDirectoryName(requesterPath);
-			var assemblyPath = Path.Combine(directory, new AssemblyName(args.Name).Name + ".dll");
-			return Assembly.LoadFile(assemblyPath);
 		}
 
 		static Func<string, bool>? CreateFilter(CommandLineArgs arguments)

--- a/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
+++ b/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
@@ -10,10 +10,6 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
+++ b/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507">
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
+++ b/src/WTG.BulkAnalysis.Runner/WTG.BulkAnalysis.Runner.csproj
@@ -8,7 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WTG.BulkAnalysis.Test/.editorconfig
+++ b/src/WTG.BulkAnalysis.Test/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+# These Roslyn Analyzer rules are designed for production grade projects, not for our little test stubs.
+# Ignore these rules in the test project to avoid unnecessary noise.
+dotnet_diagnostic.RS1036.severity = none
+dotnet_diagnostic.RS1038.severity = none
+dotnet_diagnostic.RS1041.severity = none
+dotnet_diagnostic.RS2008.severity = none

--- a/src/WTG.BulkAnalysis.Test/AnalyzerCacheTest.cs
+++ b/src/WTG.BulkAnalysis.Test/AnalyzerCacheTest.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using WTG.BulkAnalysis.Core;
+
+namespace WTG.BulkAnalysis.Test;
+
+public class AnalyzerCacheTest
+{
+	[Test]
+	public void LoadsAnalyzersFromAssembly()
+	{
+		var cache = CreateCache(SampleAnalyzer.DiagnosticId);
+
+		var analyzers = cache.GetAnalyzers(CreateProject());
+
+		Assert.That(analyzers.Select(a => a.GetType()), Has.Member(typeof(SampleAnalyzer)));
+	}
+
+	[Test]
+	public void OnlyReturnsAnalyzersForTheRequestedDiagnosticIds()
+	{
+		var cache = CreateCache("SomeOtherIdThatNothingSupports");
+
+		var analyzers = cache.GetAnalyzers(CreateProject());
+
+		Assert.That(analyzers.Select(a => a.GetType()), Has.No.Member(typeof(SampleAnalyzer)));
+	}
+
+	static AnalyzerCache CreateCache(string diagnosticId)
+	{
+		return AnalyzerCache.Create(
+			ImmutableHashSet.Create(diagnosticId),
+			loadDir: string.Empty,
+			loadList: ImmutableArray.Create(typeof(AnalyzerCacheTest).Assembly.Location),
+			log: NullLog.Instance);
+	}
+
+	static Project CreateProject()
+	{
+		var workspace = new AdhocWorkspace();
+		return workspace.AddProject("Sample", LanguageNames.CSharp);
+	}
+
+	sealed class NullLog : ILog
+	{
+		public static readonly NullLog Instance = new NullLog();
+
+		public void WriteFormatted(FormattableString message, LogLevel level = LogLevel.Normal)
+		{
+		}
+
+		public void WriteLine(string message, LogLevel level = LogLevel.Normal)
+		{
+		}
+
+		public void WriteLine()
+		{
+		}
+	}
+
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class SampleAnalyzer : DiagnosticAnalyzer
+	{
+		public const string DiagnosticId = "WTGTEST01";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+		}
+
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticId,
+			"Sample",
+			"Sample",
+			"Test",
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+	}
+}

--- a/src/WTG.BulkAnalysis.Test/WTG.BulkAnalysis.Test.csproj
+++ b/src/WTG.BulkAnalysis.Test/WTG.BulkAnalysis.Test.csproj
@@ -5,6 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <!--
+      This project hosts a fixture DiagnosticAnalyzer (AnalyzerCacheTest.SampleAnalyzer) that is
+      loaded by AnalyzerCache during tests, not shipped as a compiler extension. The analyzer
+      packaging/design rules therefore don't apply.
+    -->
+    <NoWarn>$(NoWarn);RS1036;RS1038;RS1041;RS2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WTG.BulkAnalysis.Test/WTG.BulkAnalysis.Test.csproj
+++ b/src/WTG.BulkAnalysis.Test/WTG.BulkAnalysis.Test.csproj
@@ -5,12 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <!--
-      This project hosts a fixture DiagnosticAnalyzer (AnalyzerCacheTest.SampleAnalyzer) that is
-      loaded by AnalyzerCache during tests, not shipped as a compiler extension. The analyzer
-      packaging/design rules therefore don't apply.
-    -->
-    <NoWarn>$(NoWarn);RS1036;RS1038;RS1041;RS2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR:
- Defines the .NET SDK version to use, since my dev laptop defaulted to .NET 11 Preview 😆 
- Upgrades Roslyn to latest (5.3.0, equivalent to .NET SDK 10.0.200)
- Unlocks C# 12 syntax (up from C# 11).
- Changes the way that Analyzer assemblies get loaded, since things broke on upgrade. We now use Roslyn's APIs to do this instead of hitting the .NET runtime ourselves, where possible.